### PR TITLE
Moved ember key gen install instructions

### DIFF
--- a/docs/source/frame-dev-setup.rst
+++ b/docs/source/frame-dev-setup.rst
@@ -96,7 +96,7 @@ Ember App steps
    have changed in the console where your ember server is running, like
    this:
 
-   ::
+   .. code:: bash
 
       file changed components/exp-video-config/template.hbs
 
@@ -107,40 +107,22 @@ Ember App steps
    earlier. If you are using the Lookit staging server, please contact the admins for 
    an API token for your account. Your .env file will now look like this:
 
-   ::
-
+   .. code:: bash
+   
       PIPE_ACCOUNT_HASH='<account hash here>'
       PIPE_ENVIRONMENT=<environment here>
       LOOKIT_API_KEY='Token <token here>'
       LOOKIT_API_HOST='https://localhost:8000'
-      
-    If you are using the Lookit staging server, this will be identical except that the
-    last line should be ``LOOKIT_API_HOST='https://lookit-staging.mit.edu'``.
 
-4. In order to the HTML5 video recorder, you’ll need to set up to
-   use https locally. Open ``ember-lookit-frameplayer/.ember-cli`` and
-   make sure it includes ``ssl: true``:
+   If you are using the Lookit staging server, this will be identical except that the
+   last line should be ``LOOKIT_API_HOST='https://lookit-staging.mit.edu'``.
 
-   .. code:: js
+4. Run the ember server: 
+   
+   .. code::
+   
+      yarn start
 
-      "disableAnalytics": false,
-      "ssl": true
-
-   Create ``server.key`` and ``server.crt`` files in the root
-   ``ember-lookit-frameplayer`` directory as follows:
-
-   ::
-
-      openssl genrsa -des3 -passout pass:x -out server.pass.key 2048
-      openssl rsa -passin pass:x -in server.pass.key -out server.key
-      rm server.pass.key
-      openssl req -new -key server.key -out server.csr
-      openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt
-
-   Leave the challenge password blank and enter ``localhost`` as the
-   Common Name.
-
-5. Run the ember server: ``ember serve``
 
 Starting up once initial setup is completed
 -------------------------------------------
@@ -151,19 +133,18 @@ something.
 
 1. Start the Django app:
 
-   ::
+   .. code-block:: bash
 
       $ cd lookit-api
       $ pipenv shell
       $ invoke server
       
-
 2. Start the Ember app:
 
-   ::
+   .. code-block:: bash
 
       $ cd ember-lookit-frameplayer
-      $ ember serve
+      $ yarn start
 
 3. Log in as your local superuser at http://localhost:8000/login/
 

--- a/docs/source/install-ember-app.rst
+++ b/docs/source/install-ember-app.rst
@@ -15,7 +15,8 @@ the Ember app. This way, for instance, an experiment frame will be able
 to look up previous sessions a user has completed and use those for
 longitudinal designs.
 
-   Note: These instructions are for Mac OS. Installing on another OS?
+.. note::
+   These instructions are for Mac OS. Installing on another OS?
    Please consider documenting the exact steps you take and submitting a
    PR to the lookit-api repo to update the documentation!
 
@@ -36,10 +37,10 @@ npm).
 
 .. code:: bash
 
-    git clone https://github.com/lookit/ember-lookit-frameplayer.git
-    cd ember-lookit-frameplayer
-    yarn install --pure-lockfile
-    bower install
+   git clone https://github.com/lookit/ember-lookit-frameplayer.git
+   cd ember-lookit-frameplayer
+   yarn install --pure-lockfile
+   bower install
 
 Create or open a file named ‘.env’ in the root of the
 ember-lookit-frameplayer directory, and add the following entries to use
@@ -50,17 +51,42 @@ request if you need to use the actual Lookit environments. (If you are
 doing a very large amount of local testing, we may ask that you set up
 your own Pipe account.) Your .env file should look like this:
 
-   ::
+.. code::
 
-      PIPE_ACCOUNT_HASH='<account hash here>'
-      PIPE_ENVIRONMENT=<environment here>
+   PIPE_ACCOUNT_HASH='<account hash here>'
+   PIPE_ENVIRONMENT=<environment here>
 
+In order to the HTML5 video recorder, you’ll need to set up to
+use https locally. Open ``ember-lookit-frameplayer/.ember-cli`` and
+make sure it includes ``ssl: true``:
+
+.. code:: js
+
+   "disableAnalytics": false,
+   "ssl": true
+
+Create ``server.key`` and ``server.crt`` files in the root
+``ember-lookit-frameplayer`` directory as follows:
+
+.. code-block:: bash
+
+   openssl genrsa -des3 -passout pass:x -out server.pass.key 2048
+   openssl rsa -passin pass:x -in server.pass.key -out server.key
+   rm server.pass.key
+   openssl req -new -key server.key -out server.csr
+   openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt
+
+Leave the challenge password blank and enter ``localhost`` as the
+Common Name.
 
 Running / Development
 ---------------------
 
--  ``ember serve``
--  Visit your app at http://localhost:4200.
+.. code:: bash
+
+   yarn start
+
+Visit your app at http://localhost:4200.
 
 If you change any dependencies, make sure to update and commit the yarn.lock file in 
 addition to package.json.

--- a/docs/source/install-ember-app.rst
+++ b/docs/source/install-ember-app.rst
@@ -70,14 +70,12 @@ Create ``server.key`` and ``server.crt`` files in the root
 
 .. code-block:: bash
 
-   openssl genrsa -des3 -passout pass:x -out server.pass.key 2048
-   openssl rsa -passin pass:x -in server.pass.key -out server.key
-   rm server.pass.key
-   openssl req -new -key server.key -out server.csr
-   openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt
-
-Leave the challenge password blank and enter ``localhost`` as the
-Common Name.
+   mkdir ssl
+   openssl genrsa -des3 -passout pass:x -out ssl/server.pass.key 2048
+   openssl rsa -passin pass:x -in ssl/server.pass.key -out ssl/server.key
+   rm ssl/server.pass.key
+   openssl req -new -key ssl/server.key -out ssl/server.csr -subj /CN=localhost
+   openssl x509 -req -sha256 -days 365 -in ssl/server.csr -signkey ssl/server.key -out ssl/server.crt
 
 Running / Development
 ---------------------


### PR DESCRIPTION
I moved the ssl cert key generate instructions to the ember install docs.  

Additionally, I replaced `ember serve` with `yarn start`, as `ember serve` doesn't work unless you run it in the `yarn exec...` context. 