### PR TITLE
Update rabbitmq

### DIFF
--- a/docs/source/install-django-project.rst
+++ b/docs/source/install-django-project.rst
@@ -32,13 +32,15 @@ This is the software you will need to have installed to run lookit-api locally.
    .. code-block:: shell
 
       brew install graphviz
-#. Install and start rabbitmq via brew:
+#. You will need to have `Docker installed <https://docs.docker.com/docker-for-mac/install/>`__ and running.
+#. Install and start rabbitmq via docker:
 
    .. code-block:: shell
 
-      brew install rabbitmq && brew services start rabbitmq
+      docker run -d --name lookit-rabbit --env-file .env -p 5672:5672 rabbitmq:3.8.16-management-alpine
+      docker cp ./rabbitmq.sh lookit-rabbit:/rabbitmq.sh
+      docker exec -it lookit-rabbit /bin/sh -c "sh /rabbitmq.sh"
 
-#. You will need to have `Docker installed <https://docs.docker.com/docker-for-mac/install/>`__ and running.
 #. Create a Postgres database using the following command:
    
    .. code-block:: shell
@@ -135,13 +137,13 @@ You should already have a rabbitmq server installed and running.  You can check 
 
 .. code-block:: shell
 
-   brew services list
+   docker ps -f name=lookit-rabbit
    
 If rabbitmq is not running, you can start it using:
 
 .. code-block:: shell
 
-   brew services start rabbitmq
+   docker start lookit-rabbit
 
 Then use the invoke command to start the celery worker:
 


### PR DESCRIPTION
The instructions for `rabbitmq` relied upon brew having a functional install.  This, as of this month, has become unreliable and unrepeatable.  I am proposing using docker to install and setup this server for celery.  

I am open to suggestions and alternatives.  Recently, I've been using asdf to install erlang/rabbitmq.  The only issue with this is that it takes _forever_ to install this software from source.  Docker is up and running in seconds.  

This is very much a stopgap solution until I can figure out how to get a docker-compose script working for lookit-api.