### PR TITLE
Small RST fixes

### DIFF
--- a/docs/source/community-involvement.rst
+++ b/docs/source/community-involvement.rst
@@ -1,5 +1,5 @@
 Community involvement
-========================
+================================================
 
 Currently Lookit is run by three people working at home during a
 pandemic. We had a description here of all the things we do, but really,

--- a/docs/source/community-study-approval-process.rst
+++ b/docs/source/community-study-approval-process.rst
@@ -31,7 +31,7 @@ in-lab research, it’s an opportunity to improve both the participant
 experience and the science - saving you time later. So far, researchers who were frustrated by the extra steps have been convinced once they see how much their studies improve in the process.
 
 What about external studies and 'live' sessions?
-===============================================
+================================================
 
 From the beginning of Lookit through most of 2021, all studies listed on Lookit were also run within Lookit, using the Lookit experiment runner. In contrast, the new “External Study'' type recruits participants via Lookit but the experiment itself takes place elsewhere. This opens up the possibility for researchers to run “asynchronous” studies with any desired platform (e.g., Qualtrics) or “synchronous” studies (e.g., scheduled Zoom sessions).
 

--- a/docs/source/contribute-architecture-overview.rst
+++ b/docs/source/contribute-architecture-overview.rst
@@ -56,9 +56,9 @@ The Lookit ecosystem can be described as a sort of "restaurant" architecture, if
 The "Frameplayer" and video data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-[Ember-lookit-frameplayer](https://github.com/lookit/ember-lookit-frameplayer) is an Ember application that can be "built" into a web archive (WAR) with bundled/minimized Javascript and CSS. It's the default experiment type, and currently the only one available.
+`Ember-lookit-frameplayer <https://github.com/lookit/ember-lookit-frameplayer>`_ is an Ember application that can be "built" into a web archive (WAR) with bundled/minimized Javascript and CSS. It's the default experiment type, and currently the only one available.
 
-To capture video data, we use [Pipe](https://addpipe.com/). The JS client is basically a plugin that is parameterized during the WAR build process; when properly configured it will stream video data to Pipe's servers. This data is then uploaded to Amazon S3, which, upon completion, triggers a webhook that fires a POST payload to a special [handler in our API](https://github.com/lookit/lookit-api/blob/master/exp/views/video.py#L17) that finds the video in S3 and renames it to something more searchable.
+To capture video data, we use `Pipe <https://addpipe.com/>`_. The JS client is basically a plugin that is parameterized during the WAR build process; when properly configured it will stream video data to Pipe's servers. This data is then uploaded to Amazon S3, which, upon completion, triggers a webhook that fires a POST payload to a special ` handler in our API <https://github.com/lookit/lookit-api/blob/master/exp/views/video.py#L17>`_ that finds the video in S3 and renames it to something more searchable.
 
 
 
@@ -68,7 +68,7 @@ Cluster layout
 
 Lookit is organized as a collection of Kubernetes services, backed by deployments and statefulsets:
 
-:: code::
+.. code::
 
     ❯ kubectl get services
     NAME                               TYPE           CLUSTER-IP   EXTERNAL-IP              PORT(S)                                          AGE
@@ -91,10 +91,10 @@ Lookit is organized as a collection of Kubernetes services, backed by deployment
     staging-builder           1/1     89d
     staging-lookit-rabbitmq   1/1     89d
 
-- The backing monorepo for the ``-web`` (web application), ``-builder`` (experiment builder),  ``-worker`` (celery tasks), and ``-beat`` (celery crons) resources is [lookit-api](https://github.com/lookit/lookit-api), which is a django application.
+- The backing monorepo for the ``-web`` (web application), ``-builder`` (experiment builder),  ``-worker`` (celery tasks), and ``-beat`` (celery crons) resources is `lookit-api <https://github.com/lookit/lookit-api>`_, which is a django application.
 - The ``-gcloud-sqlproxy`` resources define as a single point of egress out to a Google Cloud SQL instance, designated by the configuration file for a given environment (`production example <https://github.com/lookit/lookit-orchestrator/blob/master/kubernetes/lookit/environments/production/lookit-config.env>`__)
 - The ``-lookit-rabbitmq`` resources define a `rabbitmq <https://www.rabbitmq.com/>`__ message queue that serves as a conduit between the web application and the task runner and builder.
-- `-google-storage` is basically just an external service that we set up to allow nginx ingress to reroute requests for static assets to GCS.
+- ``-google-storage`` is basically just an external service that we set up to allow nginx ingress to reroute requests for static assets to GCS.
 
 
 Setup for a separate instance of Lookit
@@ -106,9 +106,10 @@ A good place to start if you are interested in running your own separate instanc
 
 Google Cloud Platform (GCP)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-We rely almost exclusively on GCP components to orchestrate the app. A Cloud Builder Github integration trigger is tripped on deployments to either the "develop" or "master" branches of `lookit-api`, executing the "CI" piece of the pipeline ([testing and containerization](https://github.com/lookit/lookit-api/blob/master/cloudbuild.yaml)). You can see in the `deploy-to-cluster` step that the "CD" ([deployment](https://github.com/lookit/lookit-api/blob/master/cloudbuild.yaml#L68)) piece is executed near the very end. It leverages the contents using the contents of _this_  repo, which are similarly containerized (using the GitHub integration for build triggers) and loaded into GCR for use as a [custom builder](https://cloud.google.com/cloud-build/docs/configuring-builds/use-community-and-custom-builders).
+We rely almost exclusively on GCP components to orchestrate the app. A Cloud Builder Github integration trigger is tripped on deployments to either the "develop" or "master" branches of ``lookit-api``, executing the "CI" piece of the pipeline (`testing and containerization <https://github.com/lookit/lookit-api/blob/master/cloudbuild.yaml>`_). You can see in the ``deploy-to-cluster`` step that the "CD" (`deployment <https://github.com/lookit/lookit-api/blob/master/cloudbuild.yaml#L68>`_) piece is executed near the very end. It leverages the contents of *this* repo, which are similarly containerized (using the GitHub integration for build triggers) and loaded into GCR for use as a `custom builder <https://cloud.google.com/cloud-build/docs/configuring-builds/use-community-and-custom-builders>`_.
 
 The CI pipeline is not completely generalized/parameterized, so to run your own Lookit CI pipeline, you'll want to set up your own brand new environment apart from the one that is used by the MIT instance of Lookit. To accomplish this, you'll need to set up your own Google Cloud Platform project. You'll need a few things turned on:
+
 - Kubernetes Engine
 - Cloud Builder
 - Container Registry

--- a/docs/source/frame-dev-randomizers.rst
+++ b/docs/source/frame-dev-randomizers.rst
@@ -1,5 +1,5 @@
 Custom randomizer frames
-========================
+================================================
 
 Experimenter supports a special kind of frame called ‘choice’ that
 defers determining what sequence of frames a participant will see until

--- a/docs/source/frame-dev-randomizers.rst
+++ b/docs/source/frame-dev-randomizers.rst
@@ -24,12 +24,10 @@ Generally the structure for a ‘choice’ type frame takes the form:
        ]
    }
 
-Where: - **sampler** indicates which ‘randomizer’ to use. This must
-correspond with the values defined in
-``lib/exp-player/addon/randomizers/index.js`` - **options**: an array of
-options to sample from. These should correspond with values from the
-``frames`` object defined in the experiment structure (for more on this,
-see `the experiments docs <experiments.html>`__)
+Where:
+
+- **sampler** indicates which ‘randomizer’ to use. This must correspond with the values defined in ``lib/exp-player/addon/randomizers/index.js``
+- **options**: an array of options to sample from. These should correspond with values from the ``frames`` object defined in the experiment structure (for more on this, see `the experiments docs <experiments.html>`__)
 
 Making your own
 ~~~~~~~~~~~~~~~
@@ -73,17 +71,16 @@ Which looks like:
    export default randomizer;
 
 The most important thing to note is that this module exports a single
-function. This function takes three arguments: - ``frame``: the JSON
-entry for the ‘choice’ frame in context - ``pastSessions``: an array of
-this participants past sessions of taking this experiment. See `the
-experiments docs <experiments.html>`__ for more explanation of this data
-structure - ``resolveFrame``: a copy of the ExperimentParser’s
-\_resolveFrame method with the ``this`` context of the related
-ExperimentParser bound into the function.
+function. This function takes three arguments:
 
-Additionally, this function should return a two-item array containing: -
-a list of resolved frames - the conditions used to determine that
-resolved list
+- ``frame``: the JSON entry for the ‘choice’ frame in context
+- ``pastSessions``: an array of this participants past sessions of taking this experiment. See `the experiments docs <experiments.html>`__ for more explanation of this data structure
+- ``resolveFrame``: a copy of the ExperimentParser’s \_resolveFrame method with the ``this`` context of the related ExperimentParser bound into the function.
+
+Additionally, this function should return a two-item array containing:
+
+- a list of resolved frames
+- the conditions used to determine that resolved list
 
 Let’s walk through the implementation:
 
@@ -117,7 +114,7 @@ recent to least recent.
        }
 
 Next we look at the conditions for this frame from the last session
-(``pastSessions[0].get(``\ conditions.${frame.id}\ ``)``). If that value
+(``pastSessions[0].get(`conditions.${frame.id}`)``). If that value
 is unspecified, we fall back to the first option in ``frame.options``.
 We calculate the index of that item in the available ``frame.options``,
 and increment that index by one.

--- a/docs/source/frame-dev-setup.rst
+++ b/docs/source/frame-dev-setup.rst
@@ -185,5 +185,6 @@ Further Reading / Useful Links
 - https://emberjs.com/
 - https://ember-cli.com/
 - Development Browser Extensions
-  - https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi
-  - https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/
+
+  - `for Chrome <https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi>`_
+  - `for Firefox <https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/>`_

--- a/docs/source/researchers-lag-issues.rst
+++ b/docs/source/researchers-lag-issues.rst
@@ -19,9 +19,9 @@ How much noise or lag you can tolerate is up to your sample size and study. The 
 
 Thanks to recent work by Lookit researchers, we have some more specific information about how Lookit studies using audio & video stimuli (i.e. vs. text, image, etc.) are affected by lag. **In particular, studies using video stimuli will tend to have a 150-450ms lag, i.e. appearing to the participant later than the Lookit frame data will indicate.**
 
-========================
+================================================
 Descriptions of lag with video stimuli
-========================
+================================================
 
 This section reports findings by Aaron Becker, Christian Harms, Lisa Oakes,
 Yi Lin, and Michaela DeBolt.
@@ -34,9 +34,9 @@ The team tested several browsers, internet speeds, and experiments and  observed
 
 All testing on this issue thus far has included video stimuli. And as of 9/7/2021 9:15 am the have not tested running on a windows machine.
 
-========================
+======================================================
 Descriptions of lag/offset with audio & visual stimuli
-========================
+======================================================
 
 In a related but separate issue, a few users have observed differences with experiment frame types that combine visual stimuli from one file with audio stimuli from a separate file. This makes it look to the participant like the audio they hear doesn't line up with the video they are seeing.
 
@@ -44,9 +44,9 @@ Unlike the first issue discussed above, this lag does *not* tend to happen on al
 
 This github issue documents the observed problem in more detail. One consequence of this issue is that audio cues may sometimes not be a fully reliable way to detect when another stimulus starts.
 
-========================
+================================================
 Affected browsers and experiment frames
-========================
+================================================
 
 The two officially supported browsers for Lookit are Chrome and Firefox. In the testing above, Chrome was generally found to have smaller lags than Firefox.
 

--- a/docs/source/researchers-log-in.rst
+++ b/docs/source/researchers-log-in.rst
@@ -168,7 +168,7 @@ I switched to a new phone and can't get my OTP code
 If you still have access to your old phone:
 
 1. Log in to your account and enter the OTP code using your old phone.
-2. Click "My account" or go to `https://lookit.mit.edu/account/manage/`__ and scroll down to "Manage Two-Factor Authentication."
+2. Click "My account" or go to `<https://lookit.mit.edu/account/manage/>`_ and scroll down to "Manage Two-Factor Authentication."
 3. Enter your OTP from the old phone to disable 2FA temporarily.
 4. From "Manage Two-Factor Authentication," turn 2FA back on using your new phone.
 

--- a/docs/source/researchers-style-guide.rst
+++ b/docs/source/researchers-style-guide.rst
@@ -6,9 +6,9 @@ Style guide
 
 We try to conform to some common stylistic, writing, and study design guidelines to provide a familiar and friendly experience across Lookit studies.
 
-========================
+================================================
 General language usage
-========================
+================================================
 
 1. Use casual language and terms where possible
 

--- a/docs/source/tutorial-second-study.rst
+++ b/docs/source/tutorial-second-study.rst
@@ -907,7 +907,7 @@ Putting it all together, you should now have a test-trials randomizer frame with
 About creating and hosting your stimuli
 ----------------------------------------
 
-In this example, you used stimuli already posted for you at `<www.mit.edu/~kimscott/intermodal/>`. When you create your own studies, note that you'll in general need to create and host your own stimuli. Because researchers' needs here will vary substantially, stimulus creation and hosting is outside the scope of this tutorial. However, resources are available under :ref:`stim_prep`.
+In this example, you used stimuli already posted for you at `<http://www.mit.edu/~kimscott/intermodal/>`_. When you create your own studies, note that you'll in general need to create and host your own stimuli. Because researchers' needs here will vary substantially, stimulus creation and hosting is outside the scope of this tutorial. However, resources are available under :ref:`stim_prep`.
 
 About communicating with parents
 ---------------------------------

--- a/docs/source/vision-for-lookit.rst
+++ b/docs/source/vision-for-lookit.rst
@@ -15,11 +15,15 @@ Our vision is of **a collaborative online lab**:
 -  Support/incentives for best practices (e.g. preregistration,
    publishing materials and data, clearly demarcating pilot data)
 -  Can be funded (at steady state) primarily by participating labs’
-   usage, although open to alternate models # Mission statement
-   Lower barriers to conducting and participating in rigorous,
-   reproducible developmental research that advances the understanding
-   of development and its implications for education, parenting, policy,
-   and medicine. 
+   usage, although open to alternate models
+
+Mission statement
+-------------------------
+
+Lower barriers to conducting and participating in rigorous,
+reproducible developmental research that advances the understanding
+of development and its implications for education, parenting, policy,
+and medicine. 
    
 We are committed to
 


### PR DESCRIPTION
- Several links used markdown syntax: Use RST instead.
- Bulleted lists in RST need a blank line separating them from the paragraph above.
- Make some of the section title over/underlines longer to silence the build warnings.