### PR TITLE
Updating the name of Minerva

### DIFF
--- a/docs/source/tutorial-contributing.rst
+++ b/docs/source/tutorial-contributing.rst
@@ -131,7 +131,7 @@ List of tutorial participants
 - Isabel Nichoson (Wellesley College)
 - Ginni Strehle (UT Dallas)
 - Gala Stojnić (NYU)
-- Mark Sheskin (Minerva Schools at KGI)
+- Mark Sheskin (Minerva University)
 - Eylem Altuntas (MARCS at WSU)
 - Catherine T Best (MARCS Institute, Western Sydney University, Australia)
 - Xi Jia Zhou (Stanford)


### PR DESCRIPTION
We used to be "Minerva Schools at KGI" and now we are "Minerva University"!