### PR TITLE
Update experiment runner release notes

### DIFF
--- a/docs/source/researchers-runner-releases.rst
+++ b/docs/source/researchers-runner-releases.rst
@@ -20,11 +20,11 @@ Commit SHA: 3a0056ecf62fc819b83993949a634e3d91a177b7
 
 Github pull request: https://github.com/lookit/ember-lookit-frameplayer/pull/378
 
-This update makes some changes to the `iframe` frame to make it compatible with appointment booking sites and sites that require specific names for URL query parameters (e.g. Calendly). 
-1. The `iframe` frame now allows forms to be submitted inside the iframe element. This change was necessary to allow participants complete a Calendly booking from inside the iframe. 
-2. The `iframeSrc` parameter can now be generated through the `generateProperties` parameter, which allows researchers to add custom URL parameter names/values to their `iframeSrc` URL. This change allows the iframe URL to pass the child/response IDs to websites that require specific names for custom query parameters (e.g. Calendly, where these must be called 'a1', 'a2' etc.). See the examples in the `iframe` :ref:`documentation <elf:exp-lookit-iframe>` for more information.
+There are two main changes in this update. First, the `iframe` frame now works with scheduling/booking sites and other forms. Second, for all experiments we have set a new default maximum recording duration to prevent extremely long videos. Details below and in the pull request link above.
 
-This update also fixes a bug in previous experiment runner versions, where the default maximum recording duration was too high. Now the default maximum recording duration is correctly set to 7200 seconds, which is also the upper limit. Researchers can change the maximum recording duration to any value between 1 and 7200 seconds.
+* The `iframe` frame now allows forms to be submitted inside the iframe element. This enables researchers to use booking sites and other forms inside the iframe (e.g., Calendly).
+* The `iframeSrc` parameter can now be generated through the `generateProperties` parameter, which allows researchers to add custom URL parameter names/values to their `iframeSrc` URL. This change allows the iframe URL to pass the child/response IDs to websites that require specific names for custom query parameters (e.g. Calendly, where these must be called 'a1', 'a2' etc.). See the examples in the `iframe` :ref:`documentation <elf:exp-lookit-iframe>` for more information.
+* This update fixes a bug in previous experiment runner versions, where the default maximum recording duration was too high. Now the default maximum recording duration is correctly set to 7200 seconds, which is also the upper limit. Researchers can change the maximum recording duration to any value between 1 and 7200 seconds.
 
 ----
 

--- a/docs/source/researchers-runner-releases.rst
+++ b/docs/source/researchers-runner-releases.rst
@@ -13,6 +13,21 @@ The Lookit experiment runner is regularly updated in order to add new features a
 
 ----
 
+May 8, 2024: iframe improvements; maximum recording durations
+-----------------------------------------------------------
+
+Commit SHA: 3a0056ecf62fc819b83993949a634e3d91a177b7
+
+Github pull request: https://github.com/lookit/ember-lookit-frameplayer/pull/378
+
+This update makes some changes to the `iframe` frame to make it compatible with appointment booking sites and sites that require specific names for URL query parameters (e.g. Calendly). 
+1. The `iframe` frame now allows forms to be submitted inside the iframe element. This change was necessary to allow participants complete a Calendly booking from inside the iframe. 
+2. The `iframeSrc` parameter can now be generated through the `generateProperties` parameter, which allows researchers to add custom URL parameter names/values to their `iframeSrc` URL. This change allows the iframe URL to pass the child/response IDs to websites that require specific names for custom query parameters (e.g. Calendly, where these must be called 'a1', 'a2' etc.). See the examples in the `iframe` :ref:`documentation <elf:exp-lookit-iframe>` for more information.
+
+This update also fixes a bug in previous experiment runner versions, where the default maximum recording duration was too high. Now the default maximum recording duration is correctly set to 7200 seconds, which is also the upper limit. Researchers can change the maximum recording duration to any value between 1 and 7200 seconds.
+
+----
+
 Apr 11, 2024: Add Hungarian and Basque translations
 -----------------------------------------------------------
 


### PR DESCRIPTION
This PR adds a new release note to the [Experiment Runner Releases](https://lookit.readthedocs.io/en/develop/researchers-runner-releases.html) page about the most recent EFP update (changes to `iframe` frame and maximum recording durations; see https://github.com/lookit/ember-lookit-frameplayer/pull/378).