### PR TITLE
Update experiment runner release notes: fix for video assent webcam

### DIFF
--- a/docs/source/researchers-runner-releases.rst
+++ b/docs/source/researchers-runner-releases.rst
@@ -13,6 +13,19 @@ The Lookit experiment runner is regularly updated in order to add new features a
 
 ----
 
+Jul 17, 2024: Fix webcam display in video-assent with no recording
+--------------------------------------------------------------------
+
+Commit SHA: c12289257140f2b3ca777701714785620721f7dc
+
+Github pull request: https://github.com/lookit/ember-lookit-frameplayer/pull/399
+
+This fixes a problem with the webcam display in ``video-assent`` that was introduced in the June 5th update (a5adee43e2f2498598369850dbc2d4ba1536ee6c). Specifically, the webcam display option (``showWebcam: true``) was not working when there was no recording during the trial (``recordLastPage`` and ``recordWholeProcedure`` are both ``false``). This update fixes that problem.
+
+This update also modifies the ``video-assent`` frame to center the webcam feed in the "page" content.
+
+----
+
 Jun 20, 2024: Fix clipped recordings
 -------------------------------------------------------------
 

--- a/docs/source/tutorial-next-steps.rst
+++ b/docs/source/tutorial-next-steps.rst
@@ -30,7 +30,7 @@ Although we hope this tutorial has provided a solid introduction to designing an
 
 - :ref:`Use the API to programmatically download study data<API>`
 
-- :ref:`Set up conditional logic in your studies<Conditional logic>`
+- :ref:`Set up conditional logic in your studies<elf:conditional_logic>`
 
 - :ref:`Contribute a new feature to the codebase<Contributor Guidelines>`
 


### PR DESCRIPTION
This PR adds [release notes](https://lookit.readthedocs.io/en/develop/researchers-runner-releases.html) for the [latest EFP update](https://github.com/lookit/ember-lookit-frameplayer/pull/399).

It also fixes a build error: undefined label in the Conditional Logic link.