### PR TITLE
Update EFP release notes: fr/ja translations; add video IDs to data events

### DIFF
--- a/docs/source/researchers-runner-releases.rst
+++ b/docs/source/researchers-runner-releases.rst
@@ -13,10 +13,10 @@ The Lookit experiment runner is regularly updated in order to add new features a
 
 ----
 
-Oct **TBC** 2024: French and Japanese translations; video ID logging
+Oct 4th, 2024: French and Japanese translations; video ID logging
 ------------------------------------------------------------------------
 
-Commit SHA: **TBC**
+Commit SHA: afb2fda97f9325476da70e2bc0e4602816011c60
 
 Github pull request: https://github.com/lookit/ember-lookit-frameplayer/pull/408
 

--- a/docs/source/researchers-runner-releases.rst
+++ b/docs/source/researchers-runner-releases.rst
@@ -13,6 +13,23 @@ The Lookit experiment runner is regularly updated in order to add new features a
 
 ----
 
+Oct **TBC** 2024: French and Japanese translations; video ID logging
+------------------------------------------------------------------------
+
+Commit SHA: **TBC**
+
+Github pull request: https://github.com/lookit/ember-lookit-frameplayer/pull/408
+
+This latest version of the experiment runner contains the following changes to translation options:
+- Adds a French (fr) translation option to the experiment runner. Thanks Balthazar Lauzon!
+- Updates the Japanese (ja) translations. Thanks Sho Tsuji and Rhodri Cusack!
+
+It also makes a few changes to the event logs in the data produced by an experiment:
+- Adds the video file name (``videoId``) to the experiment data for any recording-releated events, and events that occur while recording is in progress (either trial or session recording).
+- Renames the ``pipeId`` property that stores the video name to ``videoId``.
+
+----
+
 Jul 17, 2024: Fix webcam display in video-assent with no recording
 --------------------------------------------------------------------
 

--- a/docs/source/researchers-runner-releases.rst
+++ b/docs/source/researchers-runner-releases.rst
@@ -21,10 +21,12 @@ Commit SHA: afb2fda97f9325476da70e2bc0e4602816011c60
 Github pull request: https://github.com/lookit/ember-lookit-frameplayer/pull/408
 
 This latest version of the experiment runner contains the following changes to translation options:
+
 - Adds a French (fr) translation option to the experiment runner. Thanks Balthazar Lauzon!
 - Updates the Japanese (ja) translations. Thanks Sho Tsuji and Rhodri Cusack!
 
 It also makes a few changes to the event logs in the data produced by an experiment:
+
 - Adds the video file name (``videoId``) to the experiment data for any recording-releated events, and events that occur while recording is in progress (either trial or session recording).
 - Renames the ``pipeId`` property that stores the video name to ``videoId``.
 

--- a/docs/source/tutorial-contributing.rst
+++ b/docs/source/tutorial-contributing.rst
@@ -339,6 +339,7 @@ List of tutorial participants
 - Lauren Howard (Franklin & Marshall College)
 - Annie Schwartzstein (University of California, Santa Cruz)
 - Emma Smith (University of Wisconsin-Madison)
+
 Checking for and creating issues on Github
 -------------------------------------------
 


### PR DESCRIPTION
This PR updates the experiment runner updates page in the lookit docs with information about the latest EFP release. Here's what it looks like:

![Screenshot 2024-10-04 at 2 19 33 PM](https://github.com/user-attachments/assets/774315b7-9ff0-4c85-b68f-4714da8dd258)

It also fixes a build warning caused by no blank line after the tutorial contributors list.