### PR TITLE
Add section about inclusion/exclusion criteria

### DIFF
--- a/docs/source/community-study-review-basic-requirements.rst
+++ b/docs/source/community-study-review-basic-requirements.rst
@@ -22,6 +22,8 @@ You must provide complete information for each of the fields on the study form,
 including compensation information and eligibility.  :ref:`Here is a detailed
 guide<study fields>` to each of the fields on the study form. 
 
+.. _inclusion_exclusion_criteria:
+
 Inclusion/Exclusion Criteria
 ---------------------------------
 

--- a/docs/source/community-study-review-basic-requirements.rst
+++ b/docs/source/community-study-review-basic-requirements.rst
@@ -22,6 +22,25 @@ You must provide complete information for each of the fields on the study form,
 including compensation information and eligibility.  :ref:`Here is a detailed
 guide<study fields>` to each of the fields on the study form. 
 
+Inclusion/Exclusion Criteria
+---------------------------------
+
+Our website strongly encourages **inclusive practices** for families that want to participate in research studies. Our goals are to support great experiences for all families and wide-reaching science outreach. Importantly, there can be a difference between (1) who you allow to experience your study and (2) who you include in your final dataset.
+
+Thus, we suggest that you have inclusion criteria that are as broad as possible. In general:
+
+- Most studies on our website should only have age as a criteria (or, rarely, grade in school).
+- Due to logistics (e.g., the geographic scope of some ethics approvals), some studies may list country requirements.
+- When a study is about language in particular then it is allowable to include language requirements (e.g., “Because this study is about native language learning, we are only recruiting monolingual English speakers” or “Because this study is about knowing exactly two languages, we are only recruiting bilingual English and French speakers”). But studies should not list language in any other cases, and it is assumed that visitors to our site will know enough English to have a good experience with English-language studies. (Likewise, we have some studies where the study is listed in another language — such as Spanish — and then it is assumed that families signing up for such a study will speak Spanish well enough to participate!)
+
+A guiding principle you can use is to consider what percent of your potential participants a criteria would exclude. For example, you might want to exclude children with “History of head injury” but this can almost certainly be done in your dataset AFTER participation has occurred; you would allow children to participate without any mention of this, but then at the end ask a question about head injury (and any other similar questions) and exclude the data from your dataset in whatever way you pre-planned. 
+
+In contrast, imagine that you were specifically recruiting children WITH a history of head injury. This would be appropriate to list as an inclusion criterion, because to recruit your sample without stating this you would need to recruit a massive sample and then exclude the vast majority of the children who had participated (and who did not have a history of head injury).
+
+In short, you will only be able to list criteria on CHS when you make a strong case for it, including that it would be impractical/impossible to allow families to participate and then exclude their data from your dataset at the point of data analysis.
+
+All of this means that you might choose to not list your study on CHS if you are going to turn away many families rather than allowing them to experience your study.
+
 Paying participants
 --------------------
 

--- a/docs/source/researchers-set-study-fields.rst
+++ b/docs/source/researchers-set-study-fields.rst
@@ -222,6 +222,10 @@ If the child is not eligible based on the study's criteria expression, they will
 
 You may want to use the criteria expression to specify additional eligibility criteria beyond an age range - for instance, if your study is for a special population like kids with ASD or bilingual kids. In general, do **not** specify your age range here; participant eligibility checks will require the child meet the `minimum and maximum age cutoffs`_ AND these critera.
 
+.. admonition:: What criteria should I use?
+
+    CHS strongly encourages **inclusive practices** for families that want to participate in research studies. Thus, we suggest that you have inclusion criteria that are as broad as possible, so that many families can participate, knowing that you may need to exclude participants from your analysis after the data has been collected. We will review your inclusion/exclusion criteria as :ref:`part of the study review process <inclusion_exclusion_criteria>`, and you will only be able to use criteria when you make a strong case for it.
+
 Every child in the CHS database has a number of fields associated with it, ranging from gestational age to languages spoken in the home, which can be used in determining eligibility. In the study edit and create views, you can formulate your criteria expression as a boolean expression with embedded relational expressions, using a domain specific query language. 
 
 You can put together your expressions using the query fields below; the operators `AND`, `OR`, `NOT`, `<`, `<=`, `=`, `>`, and `>=`; and parentheses. If your expression is invalid you will see an error when you try to save your study.


### PR DESCRIPTION
Fixes #312

This PR adds a section about CHS's guidelines on inclusion/exclusion criteria. This section is added to the "[Basic review requirements](https://lookit.readthedocs.io/en/develop/community-study-review-basic-requirements.html)" page, and linked from the "Setting study details" page (criteria expression section).

@msheskin does this look ok?

New section on the "Basic Review Requirements" page:

![Screenshot 2024-12-23 at 1 50 01 PM](https://github.com/user-attachments/assets/cf1573d3-bb95-4e08-95ea-60a7dfe19ca5)

New box in the "Criteria Expression" section on the "Setting Study Details" page that links to the inclusion/exclusion section above:

![Screenshot 2024-12-23 at 2 06 33 PM](https://github.com/user-attachments/assets/1f5699e4-58b1-4291-9247-27d75d58d016)
