### PR TITLE
Update publications and get list from zotero

### DIFF
--- a/docs/source/_static/css/lookit.css
+++ b/docs/source/_static/css/lookit.css
@@ -102,6 +102,20 @@ div#zotero-publication-list {
     margin-bottom: 1em;
 }
 
+.rst-content ul.lookit-publication-list {
+    padding: 0;
+    text-indent: -1em;
+}
+
+.rst-content ul.lookit-publication-list li {
+    list-style-type: none !important;
+    padding-bottom: 0;
+}
+
+.rst-content ul.lookit-publication-list p {
+    line-height: 2 !important;
+}
+
 .lookit-center-text {
     text-align: center;
 }

--- a/docs/source/_static/css/lookit.css
+++ b/docs/source/_static/css/lookit.css
@@ -105,6 +105,7 @@ div#zotero-publication-list {
 .rst-content ul.lookit-publication-list {
     padding: 0;
     text-indent: -1em;
+    margin-bottom: 1em;
 }
 
 .rst-content ul.lookit-publication-list li {

--- a/docs/source/_static/css/lookit.css
+++ b/docs/source/_static/css/lookit.css
@@ -97,3 +97,15 @@ ul.tutorial-participants {
 ul.tutorial-participants li {
     padding: 0;
 }
+
+div#zotero-publication-list {
+    margin-bottom: 1em;
+}
+
+.lookit-center-text {
+    text-align: center;
+}
+
+.lookit-error-message-text {
+    color:#9a9a9a
+}

--- a/docs/source/_static/js/get_publication_list.js
+++ b/docs/source/_static/js/get_publication_list.js
@@ -2,6 +2,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const pub_div = document.getElementById('zotero-publication-list');
 
+    // Use "format=json" and "include=bib" instead of "format=bib", because the latter doesn't allow sorting by date.
+    // https://www.zotero.org/support/dev/web_api/v3/basics
     const url = "https://api.zotero.org/groups/5819486/items?format=json&include=bib&linkwrap=1&style=apa&sort=date&direction=desc&v=3";
 
     try {

--- a/docs/source/_static/js/get_publication_list.js
+++ b/docs/source/_static/js/get_publication_list.js
@@ -1,0 +1,24 @@
+document.addEventListener("DOMContentLoaded", async () => { 
+
+    const pub_div = document.getElementById('zotero-publication-list');
+
+    const url = "https://api.zotero.org/groups/5819486/items?format=json&include=bib&linkwrap=1&style=apa&sort=date&direction=desc&v=3";
+
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Response status: ${response.status}`);
+        }
+        const json = await response.json();
+        pub_div.classList.remove('lookit-center-text', 'lookit-error-message-text');
+        let item_bib_info = "";
+        json.forEach((obj, i) => {
+            item_bib_info += obj.bib;
+        });
+        pub_div.innerHTML = item_bib_info;
+    } catch (error) {
+        console.error(error.message);
+        pub_div.innerHTML = `<p class="lookit-error-message-text">Something went wrong retrieving the publications. Please try again later.</p>`;
+    }
+
+});

--- a/docs/source/_static/js/get_publication_list.js
+++ b/docs/source/_static/js/get_publication_list.js
@@ -20,7 +20,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         pub_div.innerHTML = item_bib_info;
     } catch (error) {
         console.error(error.message);
-        pub_div.innerHTML = `<p class="lookit-error-message-text">Something went wrong retrieving the publications. Please try again later.</p>`;
+        pub_div.innerHTML = `<p class="lookit-error-message-text">Something went wrong retrieving the publications. Please try again later.<br/></p>`;
     }
 
 });

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,5 +1,12 @@
 {%- extends "!layout.html" %}
 
+{%- block extrahead %}
+    <meta name="sourcename" content="{{ sourcename }}" />
+    {% if "publications" in sourcename %}
+        <script type="text/javascript" src="./_static/js/get_publication_list.js"></script>
+    {% endif %}
+{% endblock %}
+
 {% block sidebartitle %}
 
     {# From the sphinx-rtd-theme layout: https://github.com/simonw/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/layout.html #}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,3 +125,12 @@ html_context = {
     "github_version": "develop",  # Version
     "conf_py_path": "/docs/source/",  # Path in the checkout to the docs root
 }
+
+# This is a hack to get Sphinx to copy static content into the build directory
+# https://github.com/sphinx-doc/sphinx/issues/2090#issuecomment-572902572
+
+def env_get_outdated(app, env, added, changed, removed):
+    return ['index']
+
+def setup(app):
+    app.connect('env-get-outdated', env_get_outdated)

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -27,6 +27,7 @@ Here's some of the research that's come out of the CHS (formerly "Lookit") platf
 
     <div id="zotero-publication-list" class="lookit-center-text lookit-error-message-text">
         Please wait while the publication list loads...
+        <br/>
     </div>
 
 

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -30,7 +30,6 @@ Here's some of the research that's come out of the CHS (formerly "Lookit") platf
     </div>
 
 
-
 ------------------------------------------
 Conference symposia, talks, and posters
 ------------------------------------------
@@ -45,4 +44,6 @@ Conference symposia, talks, and posters
 - Casey K., Scott K., Ashton K., Gill J., Simpson E., & Bayet L. (2020) Neonatal imitation of caregivers: A feasibility pilot. The CogSci 2020 Virtual Conference.
 - Yoon, E. J., Frank, M. C. (2019). Preschool children's understanding of polite requests. Proceedings of the 41st Annual Conference of the Cognitive Science Society. `[pdf] <https://psyarxiv.com/r9zf4>`__, `[repository] <https://github.com/ejyoon/polcon>`__. 
 
-If you give a presentation or publish a paper using CHS data, please share it here! You can :ref:`propose that change directly<First PR>` or email childrenhelpingscience@gmail.com with the citation (and a PDF or video link if you want to share it here).
+.. admonition:: Please help us add to this list!
+
+    If you've given a presentation or published a paper using CHS data, please share it here! You can add to this page by completing `this Google docs form <https://docs.google.com/forms/d/e/1FAIpQLScy0DBdFNvDPsd-YkqiDkykoUmpjEfZCObOBefW7w-ekw5v0w/viewform?usp=sf_link>`__, or contact us on Slack or email (childrenhelpingscience@gmail.com).

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -21,7 +21,7 @@ However, the platform itself has been renamed to "Children Helping Science" and 
 Published articles
 -----------------------
 
-Here's some of the research that's come out of the CHS (formerly "Lookit") platform! There's a lot more in prep, soif you're interested in questions like whether someone's tried X task on CHS and how it went, we recommend asking in the #researchers channel on Slack for more up-to-date info.
+Here's some of the research that's come out of the CHS (formerly "Lookit") platform! There's a lot more in prep, so if you're interested in questions like whether someone's tried X task on CHS and how it went, we recommend asking in the #researchers channel on Slack for more up-to-date info.
 
 .. raw:: html
 

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -4,27 +4,18 @@ Publications
 
 .. _Publications:
 
----------------------------------------
-Publications using CHS data
----------------------------------------
+-----------------------
+Published articles
+-----------------------
 
-Here's some of the research that's come out of the CHS (formerly "Lookit") platform! There's a lot more in prep, so 
-if you're interested in questions like whether someone's tried X task on CHS and how it 
-went, we recommend asking in the #researchers channel on Slack for more up-to-date info.
+Here's some of the research that's come out of the CHS (formerly "Lookit") platform! There's a lot more in prep, soif you're interested in questions like whether someone's tried X task on CHS and how it went, we recommend asking in the #researchers channel on Slack for more up-to-date info.
 
-- Beckner, A.G., Voss, A.T., Oakes, L.M., Casasola, M. (2021, April). Assessing the robustness of the mental rotation change detection procedure: the importance of task and context. In symposium: Infants’ learning about object properties and categories in diverse environments. Symposium conducted at the biennial Society for Research in Child Development (Virtual).
+.. raw:: html
 
-- Bochynska, A., Scott, K., and Dillon, M. (2021, April). Bringing home Baby Euclid: Evaluating infants’ basic shape discrimination using the online platform Lookit. In symposium: Infants’ learning about object properties and categories in diverse environments. Symposium conducted at the biennial meeting of the Society for Research in Child Development (Virtual).
+    <div id="zotero-publication-list" class="lookit-center-text lookit-error-message-text">
+        Please wait while the publication list loads...
+    </div>
 
-- Casey, K., Scott, K., Ashton, K., Gill, J., Simpson, E., and Bayet, L. (2021, April). Neonatal imitation of caregivers at home: Pre-registered analyses. Poster at the biennial meeting of the Society for Research in Child Development (Virtual).
-
-- Cassamajor, K., Chu, J., Scott, K., and Schulz, L. (2021, April). A large-scale study of infant intuitive physics. Poster at the biennial meeting of the Society for Research in Child Development (Virtual).
-
-- Chalik (2021, April). Moral behavior within and across social groups. In J. Dunlea (Chair), The role of social relationships in shaping children’s socio-moral reasoning. Symposium conducted at the biennial meeting of the Society for Research in Child Development (Virtual).
-
-- Casey K., Scott K., Ashton K., Gill J., Simpson E., & Bayet L. (2020) Neonatal imitation of caregivers: A feasibility pilot. The CogSci 2020 Virtual Conference.
-
-- Yoon, E. J., Frank, M. C. (2019). Preschool children's understanding of polite requests. Proceedings of the 41st Annual Conference of the Cognitive Science Society. `[pdf] <https://psyarxiv.com/r9zf4>`__, `[repository] <https://github.com/ejyoon/polcon>`__. 
 
 If you give a presentation or publish a paper using CHS data, please share it here! You can :ref:`propose that change directly<First PR>` or email childrenhelpingscience@gmail.com with the citation (and a PDF or video link if you want to share it here).
 

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -4,6 +4,19 @@ Publications
 
 .. _Publications:
 
+---------------------
+What to cite
+---------------------
+
+.. rst-class:: lookit-publication-list
+
+- Scott, K. M. and Schulz, L. E. (2017).  Lookit (part 1): a new online platform for developmental research. Open Mind 1(1):4-14. `doi:10.1162/opmi_a_00002 <https://direct.mit.edu/opmi/article/1/1/4/2933/Lookit-Part-1-A-New-Online-Platform-for>`__
+- Scott, K. M., Chu, J., and Schulz, L. E. (2017).  Lookit (part 2): Assessing the viability of online developmental research, results from three case studies. Open Mind 1(1):15-29. `doi:10.1162/opmi_a_00001 <https://direct.mit.edu/opmi/article/1/1/15/2937/Lookit-Part-2-Assessing-the-Viability-of-Online>`__
+
+These papers introduced a prototype of Lookit and reported on the initial test studies we ran. They may have helpful information about general considerations for unmoderated online research - e.g., do we basically see similar looking times even though the environment is noisier (spoilers: yes) and can you see where kids are looking from webcam (also yes)? 
+
+However, the platform itself has been renamed to "Children Helping Science" and completely re-engineered since these studies were conducted starting in 2014, so some of the details are no longer relevant - in particular, video quality is much better and we're no longer collecting variable-framerate .flv files.
+
 -----------------------
 Published articles
 -----------------------
@@ -17,16 +30,19 @@ Here's some of the research that's come out of the CHS (formerly "Lookit") platf
     </div>
 
 
+
+------------------------------------------
+Conference symposia, talks, and posters
+------------------------------------------
+
+.. rst-class:: lookit-publication-list
+
+- Beckner, A.G., Voss, A.T., Oakes, L.M., Casasola, M. (2021, April). Assessing the robustness of the mental rotation change detection procedure: the importance of task and context. In symposium: Infants’ learning about object properties and categories in diverse environments. Symposium conducted at the biennial Society for Research in Child Development (Virtual).
+- Bochynska, A., Scott, K., and Dillon, M. (2021, April). Bringing home Baby Euclid: Evaluating infants’ basic shape discrimination using the online platform Lookit. In symposium: Infants’ learning about object properties and categories in diverse environments. Symposium conducted at the biennial meeting of the Society for Research in Child Development (Virtual).
+- Casey, K., Scott, K., Ashton, K., Gill, J., Simpson, E., and Bayet, L. (2021, April). Neonatal imitation of caregivers at home: Pre-registered analyses. Poster at the biennial meeting of the Society for Research in Child Development (Virtual).
+- Cassamajor, K., Chu, J., Scott, K., and Schulz, L. (2021, April). A large-scale study of infant intuitive physics. Poster at the biennial meeting of the Society for Research in Child Development (Virtual).
+- Chalik (2021, April). Moral behavior within and across social groups. In J. Dunlea (Chair), The role of social relationships in shaping children’s socio-moral reasoning. Symposium conducted at the biennial meeting of the Society for Research in Child Development (Virtual).
+- Casey K., Scott K., Ashton K., Gill J., Simpson E., & Bayet L. (2020) Neonatal imitation of caregivers: A feasibility pilot. The CogSci 2020 Virtual Conference.
+- Yoon, E. J., Frank, M. C. (2019). Preschool children's understanding of polite requests. Proceedings of the 41st Annual Conference of the Cognitive Science Society. `[pdf] <https://psyarxiv.com/r9zf4>`__, `[repository] <https://github.com/ejyoon/polcon>`__. 
+
 If you give a presentation or publish a paper using CHS data, please share it here! You can :ref:`propose that change directly<First PR>` or email childrenhelpingscience@gmail.com with the citation (and a PDF or video link if you want to share it here).
-
------------------------
-Original Lookit papers
------------------------
-
-These papers introduced a prototype of Lookit and reported on the initial test studies we ran. They may have helpful information about general considerations for unmoderated online research - e.g., do we basically see similar looking times even though the environment is noisier (spoilers: yes) and can you see where kids are looking from webcam (also yes)? 
-
-However, the platform itself has been renamed to "Children Helping Science" and completely re-engineered since these studies were conducted starting in 2014, so some of the details are no longer relevant - in particular, video quality is much better and we're no longer collecting variable-framerate .flv files.
-
-- Scott, K. M. and Schulz, L. E. (2017).  Lookit (part 1): a new online platform for developmental research. Open Mind 1(1):4-14. `doi:10.1162/opmi_a_00002 <https://direct.mit.edu/opmi/article/1/1/4/2933/Lookit-Part-1-A-New-Online-Platform-for>`__
-
-- Scott, K. M., Chu, J., and Schulz, L. E. (2017).  Lookit (part 2): Assessing the viability of online developmental research, results from three case studies. Open Mind 1(1):15-29. `doi:10.1162/opmi_a_00001 <https://direct.mit.edu/opmi/article/1/1/15/2937/Lookit-Part-2-Assessing-the-Viability-of-Online>`__


### PR DESCRIPTION
Fixes #455 

(This also relates to https://github.com/lookit/lookit-api/issues/1337 - those publications can be added to the Zotero library and will show up on the RTD publications page, but we would still need to update the lookit-api Publications page with the Zotero-generated list to see those citations appear there.)

This PR replaces our static list of CHS publications on the docs site with a dynamically-generated list via an API call to Zotero. Updating our [CHS Zotero library](https://www.zotero.org/groups/5819486/chs_lookit_citations) will immediately update the list on the docs page. This only affects the "Published articles" section - the "What to cite" and "Conference symposia, talks, and posters" sections are still static lists.

Changes:

- Replaces the "Publications using CHS data" section and static list with "Published articles" and a dynamically generated list from Zotero. 
- Adds a JS file that grabs the citation data from Zotero and puts it on the page.
- Adds CSS for formatting the Zotero list and matching the formatting for the static publication lists.
- Adds text during publication list loading ("Please wait while the publication list loads...") and in case of error ("Something went wrong retrieving the publications. Please try again later."), with CSS formatting.
- Moves the text about adding new citations into an admonition box, with a link to the Google docs form (instead of telling researchers to create a PR).

Screenshots:

![Screenshot 2025-01-10 at 12 56 51 PM](https://github.com/user-attachments/assets/a7bb492f-ba13-4b53-8003-1b2cb9211ece)

![Screenshot 2025-01-10 at 12 57 05 PM](https://github.com/user-attachments/assets/9931e23e-aac3-42fd-b4a1-f72e61f0c26f)

... lots more papers here omitted for space...

![Screenshot 2025-01-10 at 12 57 19 PM](https://github.com/user-attachments/assets/df47b4b1-83d4-4dce-8ff7-6b3523afadba)

Loading:

![Screenshot 2025-01-10 at 1 13 23 PM](https://github.com/user-attachments/assets/b75cff70-313a-458b-b841-d28be4549882)

Error:

![Screenshot 2025-01-10 at 1 16 18 PM](https://github.com/user-attachments/assets/71a527bd-9c1f-4fcb-870b-de748bc6e0d0)