### PR TITLE
Add instruction to install postgres for local environment

### DIFF
--- a/docs/source/install-django-project.rst
+++ b/docs/source/install-django-project.rst
@@ -31,6 +31,12 @@ Before you can begin setting your local environment, we'll need to install a cou
 
 #. Install `Docker Desktop <https://www.docker.com/products/docker-desktop/>`__.
 
+#. Install PostgreSQL.  If you're on macOS, you can install it through brew:
+
+   .. code-block:: shell
+
+      brew install postgresql
+
 Local Environment
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Summary
Developer instructions for Lookit API were missing an install dependency for the Python package `psycopg2-binary`.  I added instructions on how to install this dependency, Postgres, to the developer documentation.  

Closes #230