### PR TITLE
Publications page: increase limit and ignore attachements.

### DIFF
--- a/docs/source/_static/js/get_publication_list.js
+++ b/docs/source/_static/js/get_publication_list.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // Use "format=json" and "include=bib" instead of "format=bib", because the latter doesn't allow sorting by date.
     // https://www.zotero.org/support/dev/web_api/v3/basics
-    const url = "https://api.zotero.org/groups/5819486/items?format=json&include=bib&linkwrap=1&style=apa&sort=date&direction=desc&v=3";
+    const url = "https://api.zotero.org/groups/5819486/items?format=json&include=bib&linkwrap=1&style=apa&sort=date&direction=desc&v=3&limit=100&itemType=-attachment";
 
     try {
         const response = await fetch(url);


### PR DESCRIPTION
This PR increases the limit on the number of publications returned from the Zotero API from 25 (the default) to 100 (the maximum allowed value). This PR also adds a URL parameter that tells Zotero not to return any file attachments that are linked to the citations.

## Screenshots

![Screenshot 2025-03-10 at 10 46 12 AM](https://github.com/user-attachments/assets/5c1cae10-1742-42c0-9709-5a5591a7ed91)
![Screenshot 2025-03-10 at 10 46 25 AM](https://github.com/user-attachments/assets/5a13eb8d-3b9d-4f41-9aa4-4bf712171a55)
![Screenshot 2025-03-10 at 10 46 40 AM](https://github.com/user-attachments/assets/6d6a847b-4718-4380-88fd-9778c1070b8c)
![Screenshot 2025-03-10 at 10 46 55 AM](https://github.com/user-attachments/assets/879bddce-09cc-4038-bc1b-671f9e9aa12f)
![Screenshot 2025-03-10 at 10 47 10 AM](https://github.com/user-attachments/assets/e7fc931d-17bd-4377-8258-2f5c96b5267e)


## Notes

We currently have 61 publications in the Zotero collection. Once we go over 100, we will have passed the limit on what Zotero will return in a single request, so we'll have to update this JS to handle pagination. More info in the Zotero docs: https://www.zotero.org/support/dev/web_api/v3/basics