### PR TITLE
Add jsPsych plugins to list of available plugins

### DIFF
--- a/docs/source/researchers-experiment-data.rst
+++ b/docs/source/researchers-experiment-data.rst
@@ -193,6 +193,7 @@ The table contains information about all responses to your study. The box at the
     :alt: View individual responses table.
 
 .. _box_above_ind_resp_table:
+
 When you click on a response row in the table, details about that response are updated in the box above the table as well as in the "Response details" box at the bottom-right of the page. The bottom-left the page contains options for downloading video and data from this particular response, and for viewing/creating feedback for the family (see section :ref:`"Leaving feedback" <leaving_feedback>`).
 
 .. image:: _static/img/view_individual_responses_3.png

--- a/docs/source/researchers-jspsych-intro.rst
+++ b/docs/source/researchers-jspsych-intro.rst
@@ -25,6 +25,9 @@ The CHS jsPsych experiment runner automatically loads a set of packages from the
 - `Image button response plugin <https://www.jspsych.org/v8/plugins/image-button-response/>`__ v2.0.0: ``jsPsychImageButtonResponse``
 - `Video button response plugin <https://www.jspsych.org/v8/plugins/video-button-response/>`__ v2.0.0: ``jsPsychVideoButtonResponse``
 - `Preload plugin <https://www.jspsych.org/v8/plugins/preload/>`__ v2.0.0: ``jsPsychPreload``
+- `Survey text plugin <https://www.jspsych.org/latest/plugins/survey-text/>`__ v2.1.0: ``jsPsychSurveyText``
+- `Survey multi-choice plugin <https://www.jspsych.org/latest/plugins/survey-multi-choice/>`__ v2.1.0: ``jsPsychSurveyMultiChoice``
+- `Fullscreen plugin <https://www.jspsych.org/latest/plugins/fullscreen/>`__ v2.1.0: ``jsPsychFullscreen``
 
 We will likely add more options in the future. If there are any specific jsPsych plugins/extensions that your experiment needs, please let us know! The best way to request access to a standard jsPsych package is by creating a ``lookit-api`` `Github issue <https://github.com/lookit/lookit-api/issues>`__, but you can also let us know on Slack.
 


### PR DESCRIPTION
This PR adds the following plugins to the [list of jsPsych packages](https://lookit.readthedocs.io/en/master/researchers-jspsych-intro.html#jspsych-packages) that are available for CHS jsPsych studies:

- survey-text (already available)
- survey-multi-choice (already available)
- fullscreen (will be added soon: https://github.com/lookit/lookit-api/pull/1701)

We should wait until https://github.com/lookit/lookit-api/pull/1701 is merged before merging this.

This PR also adds a new line to fix a build warning.