### PR TITLE
Update jspsych plugin list

### DIFF
--- a/docs/source/researchers-jspsych-intro.rst
+++ b/docs/source/researchers-jspsych-intro.rst
@@ -84,6 +84,15 @@ The CHS jsPsych experiment runner automatically loads a set of packages from the
   - v2.1.0 (`see changelog <https://github.com/jspsych/jsPsych/blob/main/packages/plugin-fullscreen/CHANGELOG.md>`__)
   - ``jsPsychFullscreen``
 
+We also welcome community-developed jsPsych plugins/extensions from the `jsPsych-contrib Github repository <https://github.com/jspsych/jspsych-contrib>`__. If you have a custom plugin/extension you want to use, please submit it to jspsych-contrib for review and publishing on NPM, and then we can add it to CHS!
+
+.. rst-class:: jspsych-plugins-extensions
+
+- `Tangram game plugin <https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-tangram-game/docs/plugin-tangram-game.md>`__
+
+  - v1.0.0 (`see changelog <https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-tangram-game/CHANGELOG.md>`__)
+  - ``jsPsychTangram``
+
 .. admonition:: Need something else?
 
    If there are any specific jsPsych plugins/extensions that your experiment needs, please let us know! The best way to request access to a standard jsPsych package is by creating a ``lookit-api`` `Github issue <https://github.com/lookit/lookit-api/issues>`__, but you can also let us know on Slack.

--- a/docs/source/researchers-jspsych-intro.rst
+++ b/docs/source/researchers-jspsych-intro.rst
@@ -121,6 +121,10 @@ Current version: 7.0.0 (`see changelog <https://github.com/lookit/lookit-jspsych
 
   - ``chsRecord.VideoConsentPlugin``
 
+- `Video assent plugin <https://lookit.readthedocs.io/projects/chs-jspsych/en/latest/record/#video-assent-plugin>`__
+
+  - ``chsRecord.VideoAssentPlugin``
+
 - `Start session recording plugin <https://lookit.readthedocs.io/projects/chs-jspsych/en/latest/record/#session-recording>`__
 
   - ``chsRecord.StartRecordPlugin``

--- a/docs/source/researchers-jspsych-intro.rst
+++ b/docs/source/researchers-jspsych-intro.rst
@@ -54,12 +54,12 @@ The CHS jsPsych experiment runner automatically loads a set of packages from the
   - v2.0.0 (`see changelog <https://github.com/jspsych/jsPsych/blob/main/packages/plugin-video-button-response/CHANGELOG.md>`__)
   - ``jsPsychVideoButtonResponse``
 
-- `Image hotspots <https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-image-hotspots/docs/plugin-image-hotspots.md>`__
+- `Image hotspots plugin <https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-image-hotspots/docs/plugin-image-hotspots.md>`__
 
   - v1.1.0 (`see changelog <https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-image-hotspots/CHANGELOG.md>`__)
   - ``jsPsychImageHotspots``
 
-- `Video hotspots <https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-video-hotspots/docs/plugin-video-hotspots.md>`__
+- `Video hotspots plugin <https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-video-hotspots/docs/plugin-video-hotspots.md>`__
 
   - v1.1.0 (`see changelog <https://github.com/jspsych/jspsych-contrib/blob/main/packages/plugin-video-hotspots/CHANGELOG.md>`__)
   - ``jsPsychVideoHotspots``
@@ -100,15 +100,15 @@ The custom CHS-jsPsych packages/versions are listed below, along with links to d
 
 **CHS Record package**
 
-Current version: 6.0.0 (`see changelog <https://github.com/lookit/lookit-jspsych/blob/main/packages/record/CHANGELOG.md>`__)
+Current version: 7.0.0 (`see changelog <https://github.com/lookit/lookit-jspsych/blob/main/packages/record/CHANGELOG.md>`__)
 
 .. rst-class:: jspsych-plugins-extensions
 
-- `Video config plugin <https://lookit.readthedocs.io/projects/chs-jspsych/en/latest/record/#video-configuration>`__
+- `Video config plugin <https://lookit.readthedocs.io/projects/chs-jspsych/en/latest/record/#video-configuration-plugin>`__
 
   - ``chsRecord.VideoConfigPlugin``
 
-- `Video consent plugin <https://lookit.readthedocs.io/projects/chs-jspsych/en/latest/record/#video-consent>`__
+- `Video consent plugin <https://lookit.readthedocs.io/projects/chs-jspsych/en/latest/record/#video-consent-plugin>`__
 
   - ``chsRecord.VideoConsentPlugin``
 
@@ -120,13 +120,13 @@ Current version: 6.0.0 (`see changelog <https://github.com/lookit/lookit-jspsych
 
   - ``chsRecord.StopRecordPlugin``
 
-- `Trial recording extension <https://lookit.readthedocs.io/projects/chs-jspsych/en/latest/record/#trial-recording>`__
+- `Trial recording extension <https://lookit.readthedocs.io/projects/chs-jspsych/en/latest/record/#trial-recording-extension>`__
 
   - ``chsRecord.TrialRecordExtension``
 
 **CHS Surveys package**
 
-Current version: v6.0.1 (`see changelog <https://github.com/lookit/lookit-jspsych/blob/main/packages/surveys/CHANGELOG.md>`__)
+Current version: v7.0.0 (`see changelog <https://github.com/lookit/lookit-jspsych/blob/main/packages/surveys/CHANGELOG.md>`__)
 
 .. rst-class:: jspsych-plugins-extensions
 


### PR DESCRIPTION
This PR updates the jspsych plugins/extensions list on the jsPsych intro page:
- add new CHS jsPsych video assent plugin
- add new jspsych-contrib tangram game plugin
- update version numbers
- standardize package naming
- fix links

These changes relate to the updates made in this production release: https://github.com/lookit/lookit-api/pull/1875